### PR TITLE
Add support for TLS certificates.

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -17,5 +17,18 @@ spec:
       serviceAccountName: pipelines-app-delivery
       containers:
         - name: pipelines-app-delivery-http
-          image: quay.io/redhat-developer/gitops-backend:v0.0.2
+          image: quay.io/redhat-developer/gitops-backend:v0.0.3
           imagePullPolicy: Always
+          env:
+          - name: INSECURE
+            value: "true"
+          volumeMounts:
+            - mountPath: "/etc/gitops/ssl"
+              name: backend-ssl
+              readOnly: true
+          ports:
+          -  containerPort: 8080
+      volumes:
+      - name: backend-ssl
+        secret:
+          secretName: pipelines-app-delivery-backend

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pipelines-app-delivery-backend
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: pipelines-app-delivery-backend
   labels:
     app.kubernetes.io/name: pipelines-app-delivery-backend
 spec:


### PR DESCRIPTION
This adds the annotation from https://docs.openshift.com/container-platform/4.5/security/certificates/service-serving-certificate.html#add-service-certificate_service-serving-certificate and mounts the secret into the pod container.

This is then configured for use in `ListenAndServeTLS`.