### PR TITLE
Allow disabling the TLS certificates.

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -22,6 +22,7 @@ const (
 	insecureFlag = "insecure"
 	tlsCertFlag  = "tls-cert"
 	tlsKeyFlag   = "tls-key"
+	noTLSFlag    = "no-tls"
 )
 
 func init() {
@@ -56,6 +57,10 @@ func makeHTTPCmd() *cobra.Command {
 
 			listen := fmt.Sprintf(":%d", viper.GetInt(portFlag))
 			log.Printf("listening on %s", listen)
+			if viper.GetBool(noTLSFlag) {
+				log.Println("Not using TLS for the endpoint")
+				return http.ListenAndServe(listen, nil)
+			}
 			log.Printf("Using TLS from %q and %q", viper.GetString(tlsCertFlag), viper.GetString(tlsKeyFlag))
 			return http.ListenAndServeTLS(listen, viper.GetString(tlsCertFlag), viper.GetString(tlsKeyFlag), nil)
 		},
@@ -88,6 +93,13 @@ func makeHTTPCmd() *cobra.Command {
 		"filename for the TLS certficate",
 	)
 	logIfError(viper.BindPFlag(tlsCertFlag, cmd.Flags().Lookup(tlsCertFlag)))
+
+	cmd.Flags().Bool(
+		noTLSFlag,
+		false,
+		"do not attempt to read TLS certificates - this will serve plain HTTP",
+	)
+	logIfError(viper.BindPFlag(noTLSFlag, cmd.Flags().Lookup(noTLSFlag)))
 	return cmd
 }
 


### PR DESCRIPTION
This makes it easy to run locally on a machine for testing.