### PR TITLE
Remove argument from NewClientFactory invocation

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -123,7 +123,7 @@ func makeAPIRouter(m metrics.Interface) (*httpapi.APIRouter, error) {
 	if err != nil {
 		return nil, err
 	}
-	cf := git.NewClientFactory(git.NewDriverIdentifier(), m)
+	cf := git.NewClientFactory(m)
 	secretGetter := secrets.NewFromConfig(
 		&rest.Config{Host: config.Host},
 		viper.GetBool(insecureFlag))


### PR DESCRIPTION
Fixes 

```
go build cmd/backend-http/main.go 
# github.com/rhd-gitops-example/gitops-backend/pkg/cmd
pkg/cmd/root.go:126:28: too many arguments in call to "github.com/rhd-gitops-example/gitops-backend/pkg/git".NewClientFactory
pkg/cmd/root.go:126:29: undefined: "github.com/rhd-gitops-example/gitops-backend/pkg/git".NewDriverIdentifier
```