### PR TITLE
Drop unknown services and unnamed services.

### DIFF
--- a/pkg/httpapi/application.go
+++ b/pkg/httpapi/application.go
@@ -73,9 +73,19 @@ func parseServicesFromResources(env *environment, res []*parser.Resource) ([]res
 	services := []responseService{}
 	for k, v := range serviceImages {
 		svc := env.findService(k)
+		// If the extracted service name is not known within this environment,
+		// this drops it from the response.
+		if svc == nil {
+			continue
+		}
 		svcRepo := ""
 		if svc != nil {
 			svcRepo = svc.SourceURL
+		}
+		// This skips services where we haven't extracted a name from the
+		// labels.
+		if k == "" {
+			continue
 		}
 		rs := responseService{
 			Name:      k,

--- a/pkg/httpapi/application_test.go
+++ b/pkg/httpapi/application_test.go
@@ -170,3 +170,81 @@ func TestParseServicesFromResourcesReturnsSetOfImages(t *testing.T) {
 		t.Fatalf("parseServicesFromResources got\n%s", diff)
 	}
 }
+
+func TestParseServicesFromResourcesIgnoresEmptyServices(t *testing.T) {
+	res := []*parser.Resource{
+		{
+			Group: "apps", Version: "v1", Kind: "Deployment", Name: "go-demo-http",
+			Labels: map[string]string{},
+			Images: []string{"bigkevmcd/go-demo:876ecb3"},
+		},
+		{
+			Version: "v1", Kind: "Service", Name: "go-demo-http",
+			Labels: map[string]string{},
+		},
+	}
+	env := &environment{
+		Name:    "test-env",
+		Cluster: "https://cluster.local",
+		Apps: []*application{
+			{
+				Name: "my-app",
+				Services: []service{
+					{
+						Name:      "go-demo",
+						SourceURL: testSourceURL,
+					},
+				},
+			},
+		},
+	}
+
+	svcs, err := parseServicesFromResources(env, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []responseService{}
+	if diff := cmp.Diff(want, svcs); diff != "" {
+		t.Fatalf("parseServicesFromResources got\n%s", diff)
+	}
+}
+
+func TestParseServicesFromResourcesIgnoresUnknownServices(t *testing.T) {
+	res := []*parser.Resource{
+		{
+			Group: "apps", Version: "v1", Kind: "Deployment", Name: "go-demo-http",
+			Labels: map[string]string{
+				nameLabel:   "unknown",
+				partOfLabel: "unknown",
+			},
+			Images: []string{"bigkevmcd/go-demo:876ecb3"},
+		},
+	}
+
+	env := &environment{
+		Name:    "test-env",
+		Cluster: "https://cluster.local",
+		Apps: []*application{
+			{
+				Name: "my-app",
+				Services: []service{
+					{
+						Name:      "go-demo",
+						SourceURL: testSourceURL,
+					},
+				},
+			},
+		},
+	}
+
+	svcs, err := parseServicesFromResources(env, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []responseService{}
+	if diff := cmp.Diff(want, svcs); diff != "" {
+		t.Fatalf("parseServicesFromResources got\n%s", diff)
+	}
+}


### PR DESCRIPTION
This filters the kustomize parsed resources, to drop ones where we were unable
to extract a service name from the labels on resources.

This also drops services where the extracted label name is not in the services
for an environment.